### PR TITLE
fix: Update code to allow `next-available` for h/w reservation id in metal_device module

### DIFF
--- a/plugins/modules/metal_device.py
+++ b/plugins/modules/metal_device.py
@@ -765,12 +765,12 @@ def main():
                 operating_system = module.params.get("operating_system")
                 if (plan is None) or (operating_system is None):
                     raise Exception("plan and operating_system are required when creating a device")
-                if module.params.get("hardware_reservation_id"):
-                    hw_res = module.get_hardware_reservation()
-                    if hw_res["provisionable"] is False:
-                        module.fail_json(
-                            msg="Hardware reservation %s is not provisionable" % hw_res['id'] 
-                        )
+                # if module.params.get("hardware_reservation_id"):
+                #     hw_res = module.get_hardware_reservation()
+                #     if hw_res["provisionable"] is False:
+                #         module.fail_json(
+                #             msg="Hardware reservation %s is not provisionable" % hw_res['id'] 
+                #         )
                 fetched = module.create("metal_device")
                 if "id" not in fetched:
                     raise Exception("UUID not found in device creation response")

--- a/plugins/modules/metal_device.py
+++ b/plugins/modules/metal_device.py
@@ -765,12 +765,6 @@ def main():
                 operating_system = module.params.get("operating_system")
                 if (plan is None) or (operating_system is None):
                     raise Exception("plan and operating_system are required when creating a device")
-                # if module.params.get("hardware_reservation_id"):
-                #     hw_res = module.get_hardware_reservation()
-                #     if hw_res["provisionable"] is False:
-                #         module.fail_json(
-                #             msg="Hardware reservation %s is not provisionable" % hw_res['id'] 
-                #         )
                 fetched = module.create("metal_device")
                 if "id" not in fetched:
                     raise Exception("UUID not found in device creation response")


### PR DESCRIPTION
Fixes #224 

A device that is not privisionable will fail when we try to provision on it. Thus, removing the extra check of validation if a device is provisionable or not allows us to pass `next-available` as the h/w reservation id. 