### PR TITLE
fix: enable `metal_reserved_ip_block` to create VRF IP reservations

### DIFF
--- a/docs/modules/metal_reserved_ip_block.md
+++ b/docs/modules/metal_reserved_ip_block.md
@@ -53,6 +53,8 @@ When a user provisions first device in a facility, Equinix Metal API automatical
 | `customdata` | <center>`str`</center> | <center>Optional</center> | Custom data to associate with the reserved IP block   |
 | `comments` | <center>`str`</center> | <center>Optional</center> | Comments to associate with the reserved IP block   |
 | `vrf_id` | <center>`str`</center> | <center>Optional</center> | The ID of the VRF in which this VRF IP Reservation is created. The VRF must have an existing IP Range that contains the requested subnet.   |
+| `network` | <center>`str`</center> | <center>Optional</center> | The starting address for this VRF IP Reservation's subnet. Both IPv4 and IPv6 are supported.   |
+| `cidr` | <center>`int`</center> | <center>Optional</center> | The size of the VRF IP Reservation's subnet. The following subnet sizes are supported:<br>- IPv4: between 22 - 29 inclusive<br>- IPv6: exactly 64   |
 | `project_id` | <center>`str`</center> | <center>Optional</center> | The ID of the project to which the reserved IP block will be assigned   |
 | `tags` | <center>`list`</center> | <center>Optional</center> | Tags to associate with the reserved IP block   |
 

--- a/plugins/modules/metal_reserved_ip_block.py
+++ b/plugins/modules/metal_reserved_ip_block.py
@@ -220,6 +220,14 @@ module_spec = dict(
             'The VRF must have an existing IP Range that contains the requested subnet.',
         ],
     ),
+    network=SpecField(
+        type=FieldType.string,
+        description=['''The starting address for this VRF IP Reservation's subnet. Both IPv4 and IPv6 are supported.'''],
+    ),
+    cidr=SpecField(
+        type=FieldType.integer,
+        description=['''The size of the VRF IP Reservation's subnet. The following subnet sizes are supported:<br>- IPv4: between 22 - 29 inclusive<br>- IPv6: exactly 64'''],
+    ),
     project_id=SpecField(
         type=FieldType.string,
         description=['The ID of the project to which the reserved IP block will be assigned'],
@@ -278,10 +286,12 @@ def main():
         # argument_spec=argument_spec,
         argument_spec=SPECDOC_META.ansible_spec,
         required_one_of=[['id', 'project_id']],
-        required_by=dict(project_id=['quantity', 'type']),
+        required_by=dict(project_id=['type']),
         required_if=[
             ['type', 'vrf', ['vrf_id', 'cidr', 'network']],
-            ['type', 'public_ipv4', ['metro']]
+            ['type', 'public_ipv4', ['quantity', 'metro']],
+            ['type', 'private_ipv4', ['quantity']],
+            ['type', 'global_ipv4', ['quantity']]
         ],
     )
 


### PR DESCRIPTION
This fixes a couple problems with the parameter definitions for the reserved IP block module:

1. The `cidr` and `network` parameters, needed for VRF IP reservations, were not defined in the module spec
2. The `quantity` parameter, which is unsupported for VRF IP reservations, was required in order to create _any_ IP reservation

This PR updates the reserved IP block module so that it can be used to create a VRF IP reservation.  The docs are also updated to reference the `cidr` and `network` parameters.

This was broken out of #232.

