### PR TITLE
fix: support multiple reserved IP blocks of same type in a metro

### DIFF
--- a/plugins/modules/metal_reserved_ip_block.py
+++ b/plugins/modules/metal_reserved_ip_block.py
@@ -305,9 +305,14 @@ def main():
             fetched = module.get_by_id("metal_ip_reservation", tolerate_not_found)
         else:
             module.params['types'] = [module.params.get('type')]
+
+            attributes_to_compare = ["type", "metro"]
+            if module.params['network'] is not None:
+                attributes_to_compare.append("network")
+
             fetched = module.get_one_from_list(
                 "metal_ip_reservation",
-                ["type", "metro"],
+                attributes_to_compare,
             )
 
         if fetched:


### PR DESCRIPTION
This uses the `network` attribute, if it is specified in the task config, to differentiate between different IP reservations of the same type in the same metro.

Fixes #235 