### PR TITLE
chore(ci): disable release comments to avoid secondary rate limit

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,42 +1,43 @@
 {
-    "branches": [
-      "main"
+  "branches": [
+    "main"
+  ],
+  "ci": false,
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
     ],
-    "ci": false,
-    "plugins": [
-      [
-        "@semantic-release/commit-analyzer",
-        {
-          "preset": "conventionalcommits"
-        }
-      ],
-      [
-        "@semantic-release/release-notes-generator",
-        {
-          "preset": "conventionalcommits"
-        }
-      ],
-      [
-        "@semantic-release/github",
-        {
-          "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
-          "labels": false,
-          "releasedLabels": false
-        }
-      ],
-      [
-        "@semantic-release/exec",
-        {
-          "prepareCmd": "echo -n '${nextRelease.version}' > version && make docs"
-        }
-      ],
-      [
-        "@semantic-release/git",
-        {
-          "message": "ci: regenerate code for version ${nextRelease.version} triggered by ${process.env.RELEASE_REQUESTER}",
-          "assets": ["."]
-        }
-      ]
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "labels": false,
+        "releasedLabels": false
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "echo -n '${nextRelease.version}' > version && make docs"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "message": "ci: regenerate code for version ${nextRelease.version} triggered by ${process.env.RELEASE_REQUESTER}",
+        "assets": [
+          "."
+        ]
+      }
     ]
-  }
-
+  ]
+}


### PR DESCRIPTION
The release workflow occasionally fails due to GitHub API rate limiting on the success comments that are posted to every issue and PR that is included in the release.  While it's possible this problem has been addressed in the latest version of `semantic-release/github`, I still think it's better to disable those comments and avoid the problem entirely.