### PR TITLE
feat:  expose service tokens for Metal connections

### DIFF
--- a/plugins/module_utils/metal/metal_api.py
+++ b/plugins/module_utils/metal/metal_api.py
@@ -281,6 +281,7 @@ METAL_CONNECTION_RESPONSE_ATTRIBUTE_MAP = {
     'ports': 'ports',
     'requested_by': 'requested_by',
     'status': 'status',
+    'service_tokens': optional('service_tokens')
 }
 
 def private_ipv4_subnet_size(resource: dict):


### PR DESCRIPTION
This updates the API response mapper for Metal connections so that Ansible collection users can access `service_tokens` for a Metal connection without having to go to the [Equinix Metal console](https://console.equinix.com).